### PR TITLE
Package project for installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,14 @@ dependencies = [
     "numpy>=2.2.4",
     "pandas>=2.2.3",
 ]
+
+[project.scripts]
+stata_mcp = "stata_mcp:main"
+
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+py-modules = ["stata_mcp", "gen_stata_code_MCP", "usable"]
+packages = ["utils"]

--- a/stata_mcp.py
+++ b/stata_mcp.py
@@ -605,5 +605,10 @@ def stata_do(dofile_path: str) -> str:
     return log_file
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """Entry point for the command line interface."""
     mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add setuptools configuration in `pyproject.toml`
- expose a console script `stata_mcp`
- provide a `main` function for the CLI

## Testing
- `pip install -e .` *(fails: Could not fetch build dependencies)*
- `python -m stata_mcp --help` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68464d825d088320b324f0156d3cd200