### PR TITLE
Add initial guard to block Stata shell-escape directives

### DIFF
--- a/src/stata_mcp/core/stata/stata_do/do.py
+++ b/src/stata_mcp/core/stata/stata_do/do.py
@@ -85,10 +85,7 @@ class StataDo:
                 dofile_content = f.read()
             _validate_dofile_content(dofile_content)
         except Exception as e:
-            return {
-                "error": str(e),
-                "dofile_path": dofile_path,
-            }
+            return f"There is a security in {dofile_path}, error: {e}"
         # ===== End of initial security guard =====
                            
         nowtime = get_nowtime()


### PR DESCRIPTION
Add a validation step before executing a do-file. The guard rejects do-files containing Stata shell-escape directives (`!cmd`, `shell cmd`) to prevent OS command execution. This corresponds to the first part of the fix discussed in Issue #20.