### PR TITLE
Add Excel support to get_data_info

### DIFF
--- a/src/stata_mcp/core/data_info/__init__.py
+++ b/src/stata_mcp/core/data_info/__init__.py
@@ -1,7 +1,9 @@
 from .csv import CsvDataInfo
 from .dta import DtaDataInfo
+from .xlsx import ExcelDataInfo
 
 __all__ = [
     "CsvDataInfo",
     "DtaDataInfo",
+    "ExcelDataInfo",
 ]

--- a/src/stata_mcp/core/data_info/xlsx.py
+++ b/src/stata_mcp/core/data_info/xlsx.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2025 - Present Sepine Tam, Inc. All Rights Reserved
+#
+# @Author : Sepine Tam (谭淞)
+# @Email  : sepinetam@gmail.com
+# @File   : xlsx.py
+
+from pathlib import Path
+from urllib.parse import urlparse
+
+import pandas as pd
+
+from ._base import DataInfoBase
+
+
+class ExcelDataInfo(DataInfoBase):
+    def _read_data(self) -> pd.DataFrame:
+        """
+        Read Excel file into pandas DataFrame.
+
+        Supports .xlsx and .xls files from local paths or URLs.
+
+        Returns:
+            pd.DataFrame: The data from the Excel file
+
+        Raises:
+            FileNotFoundError: If the local file does not exist
+            ValueError: If the file is not a valid Excel file
+        """
+        valid_extensions = {".xlsx", ".xls"}
+
+        if self.is_url:
+            parsed_url = urlparse(str(self.data_path))
+            if Path(parsed_url.path).suffix.lower() not in valid_extensions:
+                raise ValueError(f"URL must point to an Excel file with extensions {valid_extensions}")
+            source = str(self.data_path)
+        else:
+            file_path = Path(self.data_path)
+
+            if not file_path.exists():
+                raise FileNotFoundError(f"Excel file not found: {file_path}")
+
+            if file_path.suffix.lower() not in valid_extensions:
+                raise ValueError(f"File must have extension in {valid_extensions}, got: {file_path.suffix}")
+
+            source = file_path
+
+        try:
+            df = pd.read_excel(source, **self.kwargs)
+            return df
+        except TypeError as e:
+            if "unexpected keyword argument" in str(e):
+                filtered_kwargs = {k: v for k, v in self.kwargs.items() if k in {"sheet_name", "header", "names"}}
+                df = pd.read_excel(source, **filtered_kwargs)
+                return df
+            raise ValueError(f"Error reading Excel file {source}: {str(e)}")
+        except Exception as e:
+            raise ValueError(f"Error reading Excel file {source}: {str(e)}")

--- a/src/stata_mcp/mcp_servers.py
+++ b/src/stata_mcp/mcp_servers.py
@@ -20,7 +20,7 @@ from typing import Dict, List, Optional, Union
 
 from mcp.server.fastmcp import FastMCP, Icon, Image
 
-from .core.data_info import CsvDataInfo, DtaDataInfo
+from .core.data_info import CsvDataInfo, DtaDataInfo, ExcelDataInfo
 from .core.stata import StataDo, StataFinder
 from .core.stata.builtin_tools import StataHelp as Help
 from .core.stata.builtin_tools.ado_install import GITHUB_Install, NET_Install, SSC_Install
@@ -293,7 +293,7 @@ def get_data_info(data_path: str | Path,
 
     Args:
         data_path (str): the data file's absolutely path.
-            Current, only allow [dta, csv] file.
+            Current, only allow [dta, csv, xlsx, xls] file.
         vars_list (Optional[List[str]]): the vars you want to get info (default is None, means all vars).
         encoding (str): data file encoding method (dta file is not supported this arg),
             if you do not know your data ignore this arg, for most of the data files are `UTF-8`.
@@ -325,6 +325,8 @@ def get_data_info(data_path: str | Path,
     CLASS_MAPPING = {
         "dta": DtaDataInfo,
         "csv": CsvDataInfo,
+        "xlsx": ExcelDataInfo,
+        "xls": ExcelDataInfo,
     }
 
     data_path = Path(data_path).expanduser().resolve()


### PR DESCRIPTION
## Summary
- add an ExcelDataInfo helper to read xlsx and xls files through pandas
- expose the Excel handler and map both extensions in `get_data_info`
- keep the existing data info interface while expanding supported formats

## Testing
- python -m compileall src/stata_mcp

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954ca526c108320882abededd399d3c)