### PR TITLE
Add cached summary loader for DataInfoBase

### DIFF
--- a/src/stata_mcp/core/data_info/_base.py
+++ b/src/stata_mcp/core/data_info/_base.py
@@ -251,9 +251,6 @@ class DataInfoBase(ABC):
         """
         Provide a summary of the data.
 
-        Args:
-            saved_path (str): If you want to save the result into a json, config this arg with absloute path.
-
         Returns:
             Dict[str, Any]: the summary of provided data (vars)
 
@@ -303,6 +300,10 @@ class DataInfoBase(ABC):
                 }
             }
         """
+        if self.is_cache:
+            cached_summary = self.load_cached_summary()
+            if cached_summary:
+                return self._filter(cached_summary)
         df = self.df
         selected_vars = self.vars_list
 


### PR DESCRIPTION
## Summary
- add the dataset hash to the overview section of cached summaries
- add a cache loading helper that validates the hash and variable coverage before reuse
- add a variable-level cache filter to return only the requested fields

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959ce9b256c8320933b973d31deeaa0)