### PR TITLE
Add `clear` before exiting Stata on Unix do-file execution

### DIFF
--- a/src/stata_mcp/stata/stata_do/do.py
+++ b/src/stata_mcp/stata/stata_do/do.py
@@ -181,6 +181,7 @@ class StataDo:
             {self.generate_log_command(smcl_file, is_replace, 'smcl') if enable_smcl else ''}
             do "{dofile_path}"
             log close _all
+            clear
             exit, STATA
             """
             _, stderr = proc.communicate(input=commands)  # Send commands and wait for completion
@@ -296,6 +297,7 @@ class StataDo:
             {self.generate_log_command(smcl_file, is_replace, 'smcl') if enable_smcl else ''}
             do "{dofile_path}"
             log close _all
+            clear
             exit, STATA
             """
 


### PR DESCRIPTION
### Motivation
- Prevent Stata from blocking exit with `r(4)` when a do-file modifies the in-memory dataset in Unix-like automation runs, which can leave hanging processes. 
- Ensure MCP-driven Stata invocations always terminate cleanly without changing user do-files or Windows behavior.

### Description
- Inserted `clear` between `log close _all` and `exit, STATA` for Unix-like execution in `_execute_unix_like` to discard in-memory changes before exit. 
- Made the same insertion in `_execute_unix_like_with_monitors` so monitored executions behave the same. 
- Left Windows execution paths (`_execute_windows` and `_execute_windows_with_monitors`) unchanged.

### Testing
- Ran lint on the modified file: `uv run ruff check src/stata_mcp/stata/stata_do/do.py`, which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e350197fa08320b4dc573c775bb52c)