### PR TITLE
Replace is_read_log with read_log_when_error in stata_do

### DIFF
--- a/src/stata_mcp/api/ado_install.py
+++ b/src/stata_mcp/api/ado_install.py
@@ -62,4 +62,4 @@ def ado_package_install(
     replace_flag = "replace" if is_replace else ""
     command = f"{source} install {package}, {replace_flag} {from_message}".strip()
     dofile_path = write_dofile(command, config_file=config_file)
-    return str(stata_do(dofile_path, is_read_log=True, config_file=config_file).get("log_content", {}))
+    return str(stata_do(dofile_path, read_log_when_error=False, config_file=config_file).get("log_content", {}))

--- a/src/stata_mcp/api/stata_do.py
+++ b/src/stata_mcp/api/stata_do.py
@@ -8,6 +8,7 @@
 # @File   : stata_do.py
 
 from pathlib import Path
+import re
 from typing import Any, Dict
 
 from ..core.types import RAMLimitExceededError
@@ -20,12 +21,12 @@ from ._runtime import create_runtime_context
 def stata_do(
     dofile_path: str,
     log_file_name: str = None,
-    is_read_log: bool = True,
+    read_log_when_error: bool = False,
     is_replace_log: bool = True,
     enable_smcl: bool = True,
     config_file: str | Path | None = None,
 ) -> Dict[str, Any]:
-    """Execute a Stata do-file and optionally return log content."""
+    """Execute a Stata do-file and optionally return log content when errors occur."""
     runtime = create_runtime_context(config_file=config_file, require_stata=True)
 
     try:
@@ -87,11 +88,24 @@ def stata_do(
         }
     }
 
-    if is_read_log:
+    if read_log_when_error:
         text_log_reader = StataLog.from_path(text_log_path)
-        log_content = {"text": text_log_reader.read_without_framework()}
+        text_content = text_log_reader.read_without_framework()
+
+        if not _has_stata_error(text_content):
+            text_content = (
+                "There is no Stata return-code error in this execution. "
+                "If you want to view the full log, use the read_log tool."
+            )
+
+        log_content = {"text": text_content}
         if enable_smcl and "smcl" in log_file_path_mapping:
             log_content["smcl"] = log_file_path_mapping["smcl"].as_posix()
         result["log_content"] = log_content
 
     return result
+
+
+def _has_stata_error(content: str) -> bool:
+    """Return True when the text log contains a Stata return code pattern like r(198)."""
+    return re.search(r"r\(\d+\)", content) is not None

--- a/src/stata_mcp/api/stata_help.py
+++ b/src/stata_mcp/api/stata_help.py
@@ -15,13 +15,12 @@ from ._runtime import create_runtime_context
 
 def stata_help(
     cmd: str,
-    is_read_log: bool = True,
     enable_smcl: bool = True,
     config_file: str | Path | None = None,
 ) -> str:
     """Return help content for a Stata command through a one-shot helper."""
     runtime = create_runtime_context(config_file=config_file, require_stata=True)
-    _ = (is_read_log, enable_smcl)
+    _ = enable_smcl
     help_reader = StataHelp(
         stata_cli=runtime.stata_cli,
         project_tmp_dir=runtime.tmp_base_path,

--- a/src/stata_mcp/cli/_handlers.py
+++ b/src/stata_mcp/cli/_handlers.py
@@ -107,14 +107,13 @@ def handle_tool(args: Namespace) -> int:
             result = stata_do(
                 dofile_path=args.dofile_path,
                 log_file_name=args.log_file_name,
-                is_read_log=args.is_read_log,
+                read_log_when_error=args.is_read_log,
                 is_replace_log=args.is_replace_log,
                 enable_smcl=args.enable_smcl,
             )
         elif args.tool_action == "help":
             result = stata_help(
                 cmd=args.stata_command,
-                is_read_log=args.is_read_log,
                 enable_smcl=args.enable_smcl,
             )
         elif args.tool_action == "data-info":

--- a/src/stata_mcp/mcp_servers.py
+++ b/src/stata_mcp/mcp_servers.py
@@ -10,6 +10,7 @@
 import json
 import logging
 import logging.handlers
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Literal
@@ -137,7 +138,7 @@ def help(cmd: str, replace: bool = False) -> str:
 def stata_do(
         dofile_path: str,
         log_file_name: str = None,
-        is_read_log: bool = True,
+        read_log_when_error: bool = False,
         is_replace_log: bool = True,
         enable_smcl: bool = True
 ) -> Dict[str, Any]:
@@ -151,8 +152,8 @@ def stata_do(
         dofile_path (str): Absolute or relative path to the Stata do-file (.do) to execute.
         log_file_name (str, optional): Set log file name without a time-string.
             If None, using nowtime as filename. Recommand use default setting (nowtime).
-        is_read_log (bool, optional): Whether to read and return the log file content.
-            Defaults to True.
+        read_log_when_error (bool, optional): Whether to read the text log only when checking for
+            Stata return-code errors like r(198). Defaults to False.
         is_replace_log (bool, optional): Whether to replace existing log file.
             Defaults to True.
         enable_smcl (bool, optional): Whether to generate SMCL format log (.smcl).
@@ -164,7 +165,7 @@ def stata_do(
             - "log_file_path" (Dict[str, str]): Paths to generated log files.
                 - "text": Path to .log file
                 - "smcl": Path to .smcl file (if enable_smcl is True)
-            - "log_content" (Dict[str, str]): Content of log files if is_read_log is True.
+            - "log_content" (Dict[str, str]): Content of log files if read_log_when_error is True.
                 - "text": Content of .log file
                 - "smcl": Message about reading smcl log
             - "error" (str): Error message if execution fails
@@ -175,7 +176,7 @@ def stata_do(
         PermissionError: If there are insufficient permissions to execute Stata or write log files
 
     Example:
-        >>> result = stata_do("/path/to/analysis.do", is_read_log=True)
+        >>> result = stata_do("/path/to/analysis.do", read_log_when_error=True)
         {
             "log_file_path": {
                 "text": "/path/to/your/log/log_file_name.log",
@@ -286,8 +287,15 @@ def stata_do(
     }
 
     # Return log content based on user preference
-    if is_read_log:
-        log_content = {"text": stata_executor.read_log(text_log)}
+    if read_log_when_error:
+        text_content = stata_executor.read_log(text_log)
+        if not _has_stata_error(text_content):
+            text_content = (
+                "There is no Stata return-code error in this execution. "
+                "If you want to view the full log, use the read_log tool."
+            )
+
+        log_content = {"text": text_content}
         if enable_smcl:
             log_content["smcl"] = (
                 "Generally, text log is sufficient."
@@ -413,7 +421,7 @@ def ado_package_install(
         from_message = f"from({package_source_from})" if (package_source_from and source == "net") else ""
         replace_str = "replace" if is_replace else ""
         tmp_file = write_dofile(f"{source} install {package}, {replace_str} {from_message}")
-        return stata_do(tmp_file, is_read_log=True).get("log_content")
+        return stata_do(tmp_file, read_log_when_error=False).get("log_content")
 
 
 # =============================================================================
@@ -631,6 +639,11 @@ def _trim_lines(content: str, lines: int) -> str:
     return "\n".join(all_lines[-abs(lines):])
 
 
+def _has_stata_error(content: str) -> bool:
+    """Return True when the text log contains a Stata return code pattern like r(198)."""
+    return re.search(r"r\(\d+\)", content) is not None
+
+
 def write_dofile(content: str, encoding: str = None) -> str:
     """
     Write stata code to a dofile and return the do-file path.
@@ -673,7 +686,7 @@ _TOOL_REGISTRY: Dict[str, Dict[str, Any]] = {
         "description": (
             "Execute a Stata do-file and return the execution log. "
             "Accepts a do-file path, runs it via the configured Stata executable, "
-            "and optionally returns the log content."
+            "and can optionally read log content only when return-code errors are detected."
         ),
         "func": stata_do,
         "profiles": {"core", "all"},


### PR DESCRIPTION
### Motivation
- Change `stata_do` behavior to avoid reading full logs by default and only read text logs when checking for Stata return-code errors (pattern `r(\d+)`).
- Provide a clear informational message when no return-code error is found, and keep existing behavior when callers explicitly opt out of reading logs.
- Remove an unused `is_read_log` parameter from `stata_help` and update callers and CLI wiring to match the new API.

### Description
- Updated `src/stata_mcp/api/stata_do.py` to replace the `is_read_log` parameter with `read_log_when_error: bool = False`, added conditional log-reading logic, and introduced the helper `_has_stata_error(content: str) -> bool` using `re.search(r"r\(\d+\)", ...)` to detect Stata return-code errors.
- Adjusted `src/stata_mcp/api/ado_install.py` to call `stata_do(..., read_log_when_error=False)` when invoking the non-Unix installation flow.
- Removed the unused `is_read_log` parameter from `src/stata_mcp/api/stata_help.py` and simplified its local unused-variable handling.
- Updated `src/stata_mcp/mcp_servers.py` to expose the MCP tool with `read_log_when_error` in the `stata_do` signature, added `import re`, inserted `_has_stata_error` helper, and updated docs/tool description to reflect the new semantics.
- Updated CLI wiring in `src/stata_mcp/cli/_handlers.py` so the `do` tool maps the existing CLI `--is-read-log` flag to the new `read_log_when_error` argument and removed the obsolete `is_read_log` pass-through for `help`.

### Testing
- Ran unit tests with `PYTHONPATH=src pytest -q`, which completed successfully (10 tests passed).
- Compiled updated modules with `python -m compileall src/stata_mcp/api/stata_do.py src/stata_mcp/api/ado_install.py src/stata_mcp/api/stata_help.py src/stata_mcp/mcp_servers.py src/stata_mcp/cli/_handlers.py`, which succeeded without errors.
- Note: a plain `pytest -q` run without `PYTHONPATH=src` fails in this environment due to import path setup, but the tests pass when `src` is added to `PYTHONPATH`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e36826da908320aae4ffc57a1c2cf6)