### PR TITLE
feat(doctor): add cleanup check and --dry-run support

### DIFF
--- a/src/stata_mcp/cli/_handlers.py
+++ b/src/stata_mcp/cli/_handlers.py
@@ -72,7 +72,7 @@ def handle_doctor(args: Namespace) -> int:
         print(f"Failed to initialize configuration for doctor: {error}", file=sys.stderr)
         return 1
 
-    report = run_doctor(config, only_checks=args.checks)
+    report = run_doctor(config, only_checks=args.checks, dry_run=args.dry_run)
 
     if args.output_json:
         print(report.to_json())

--- a/src/stata_mcp/cli/_parsers.py
+++ b/src/stata_mcp/cli/_parsers.py
@@ -249,6 +249,11 @@ def add_doctor_parser(subparsers: argparse._SubParsersAction) -> argparse.Argume
         default=None,
         help="Run only specified check names (repeatable)",
     )
+    doctor_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview cleanup actions without deleting files",
+    )
     return doctor_parser
 
 

--- a/src/stata_mcp/config.py
+++ b/src/stata_mcp/config.py
@@ -377,6 +377,16 @@ class Config:
         return StataMcpFolder(self.WORKING_DIR / "stata-mcp-folder")
 
     @property
+    def CLEAN_LOG_DAYS(self) -> int:
+        return self._get_config_value(
+            config_keys=["PROJECT", "CLEAN_LOG_DAYS"],
+            env_var="STATA_MCP__CLEAN_LOG_DAYS",
+            default=-1,
+            converter=self._to_int,
+            validator=lambda x: isinstance(x, int),
+        )
+
+    @property
     def PROJECT_NAME(self) -> str:
         return self.WORKING_DIR.name
 

--- a/src/stata_mcp/utils/clean_log.py
+++ b/src/stata_mcp/utils/clean_log.py
@@ -56,7 +56,12 @@ def scan_old_files(dirs: list[Path], max_age_days: int, now: datetime | None = N
     return results
 
 
-def clean_log_files(max_age_days: int, dry_run: bool = False, config: Config | None = None) -> dict[str, Any]:
+def clean_log_files(
+    max_age_days: int,
+    dry_run: bool = False,
+    config: Config | None = None,
+    candidate_files: list[Path] | None = None,
+) -> dict[str, Any]:
     """Clean old timestamped files from log/do/tmp folders."""
     if config is None:
         from ..config import Config
@@ -69,7 +74,11 @@ def clean_log_files(max_age_days: int, dry_run: bool = False, config: Config | N
         cfg.STATA_MCP_FOLDER.DO,
         cfg.STATA_MCP_FOLDER.TMP,
     ]
-    candidates = scan_old_files(target_dirs, max_age_days=max_age_days)
+    candidates = (
+        candidate_files
+        if candidate_files is not None
+        else scan_old_files(target_dirs, max_age_days=max_age_days)
+    )
     candidate_size = 0
     for path in candidates:
         try:

--- a/src/stata_mcp/utils/clean_log.py
+++ b/src/stata_mcp/utils/clean_log.py
@@ -1,0 +1,119 @@
+"""Utilities for scanning and cleaning timestamped files in stata-mcp folders."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ..config import Config
+
+_TIMESTAMP_PATTERN = re.compile(r"^(\d{14})(\d{6})?")
+
+
+def _parse_timestamp_from_stem(stem: str) -> datetime | None:
+    """Parse a leading timestamp from file stem."""
+    match = _TIMESTAMP_PATTERN.match(stem)
+    if match is None:
+        return None
+
+    main_part = match.group(1)
+    microseconds = match.group(2)
+    if microseconds:
+        stamp = f"{main_part}{microseconds}"
+        fmt = "%Y%m%d%H%M%S%f"
+    else:
+        stamp = main_part
+        fmt = "%Y%m%d%H%M%S"
+
+    try:
+        return datetime.strptime(stamp, fmt)
+    except ValueError:
+        return None
+
+
+def scan_old_files(dirs: list[Path], max_age_days: int, now: datetime | None = None) -> list[Path]:
+    """Scan non-recursively and return files older than max_age_days."""
+    current_time = now or datetime.now()
+    effective_days = max(max_age_days, 0)
+    cutoff = current_time - timedelta(days=effective_days)
+    results: list[Path] = []
+
+    for directory in dirs:
+        if not directory.exists() or not directory.is_dir():
+            continue
+        for path in directory.iterdir():
+            if not path.is_file():
+                continue
+            file_timestamp = _parse_timestamp_from_stem(path.stem)
+            if file_timestamp is None:
+                continue
+            if file_timestamp <= cutoff:
+                results.append(path)
+
+    return results
+
+
+def clean_log_files(max_age_days: int, dry_run: bool = False, config: Config | None = None) -> dict[str, Any]:
+    """Clean old timestamped files from log/do/tmp folders."""
+    if config is None:
+        from ..config import Config
+
+        cfg = Config()
+    else:
+        cfg = config
+    target_dirs = [
+        cfg.STATA_MCP_FOLDER.LOG,
+        cfg.STATA_MCP_FOLDER.DO,
+        cfg.STATA_MCP_FOLDER.TMP,
+    ]
+    candidates = scan_old_files(target_dirs, max_age_days=max_age_days)
+    candidate_size = 0
+    for path in candidates:
+        try:
+            candidate_size += path.stat().st_size
+        except OSError:
+            continue
+
+    if dry_run:
+        return {
+            "deleted_count": 0,
+            "skipped_count": len(candidates),
+            "failed_count": 0,
+            "freed_bytes": candidate_size,
+            "errors": [],
+            "dry_run": True,
+        }
+
+    deleted_count = 0
+    skipped_count = 0
+    failed_count = 0
+    freed_bytes = 0
+    errors: list[dict[str, str]] = []
+
+    for file_path in candidates:
+        if not file_path.exists():
+            skipped_count += 1
+            continue
+        try:
+            size = file_path.stat().st_size
+        except OSError:
+            size = 0
+        try:
+            file_path.unlink()
+            deleted_count += 1
+            freed_bytes += size
+        except OSError as error:
+            failed_count += 1
+            errors.append({"path": str(file_path), "error": str(error)})
+
+    return {
+        "deleted_count": deleted_count,
+        "skipped_count": skipped_count,
+        "failed_count": failed_count,
+        "freed_bytes": freed_bytes,
+        "errors": errors,
+        "dry_run": False,
+    }

--- a/src/stata_mcp/utils/doctor.py
+++ b/src/stata_mcp/utils/doctor.py
@@ -28,6 +28,8 @@ from typing import Any
 from urllib.error import URLError
 from urllib.request import Request, urlopen
 
+from .clean_log import clean_log_files, scan_old_files
+
 
 class CheckStatus(Enum):
     """Status values for a doctor check."""
@@ -594,7 +596,86 @@ def check_pypi() -> CheckResult:
         )
 
 
-def _all_checks(config: Any) -> list[tuple[str, Any]]:
+def _format_size(size_bytes: int) -> str:
+    """Return a human-readable file size."""
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+    for unit in ["KB", "MB", "GB", "TB"]:
+        size_bytes /= 1024
+        if size_bytes < 1024:
+            return f"{size_bytes:.1f} {unit}"
+    return f"{size_bytes:.1f} PB"
+
+
+def check_cleanup(config: Any, dry_run: bool = False) -> CheckResult:
+    """Check and optionally clean old timestamped files."""
+    clean_days = config.CLEAN_LOG_DAYS
+    scan_days = clean_days if clean_days > 0 else 365
+    target_dirs = [
+        config.STATA_MCP_FOLDER.LOG,
+        config.STATA_MCP_FOLDER.DO,
+        config.STATA_MCP_FOLDER.TMP,
+    ]
+
+    old_files = scan_old_files(target_dirs, max_age_days=scan_days)
+    old_files_count = len(old_files)
+    total_size = 0
+    for file_path in old_files:
+        try:
+            total_size += file_path.stat().st_size
+        except OSError:
+            continue
+
+    if clean_days == -1:
+        return CheckResult(
+            name="cleanup",
+            status=CheckStatus.PASS,
+            message=(
+                f"{old_files_count} old files ({_format_size(total_size)}) "
+                "found; cleanup disabled (CLEAN_LOG_DAYS=-1)"
+            ),
+            details={
+                "old_files": old_files_count,
+                "size_bytes": total_size,
+                "auto_clean": False,
+                "dry_run": dry_run,
+                "clean_log_days": clean_days,
+            },
+        )
+
+    result = clean_log_files(max_age_days=clean_days, dry_run=dry_run, config=config)
+    if dry_run:
+        return CheckResult(
+            name="cleanup",
+            status=CheckStatus.PASS,
+            message=(
+                f"dry-run: {result['skipped_count']} files "
+                f"({_format_size(result['freed_bytes'])}) can be cleaned"
+            ),
+            details=result,
+        )
+
+    if result["failed_count"] > 0:
+        return CheckResult(
+            name="cleanup",
+            status=CheckStatus.WARN,
+            message=(
+                f"cleaned {result['deleted_count']} files ({_format_size(result['freed_bytes'])}), "
+                f"{result['failed_count']} failed"
+            ),
+            details=result,
+            hint="Check file permissions for failed paths in cleanup.errors.",
+        )
+
+    return CheckResult(
+        name="cleanup",
+        status=CheckStatus.PASS,
+        message=f"cleaned {result['deleted_count']} files ({_format_size(result['freed_bytes'])})",
+        details=result,
+    )
+
+
+def _all_checks(config: Any, dry_run: bool = False) -> list[tuple[str, Any]]:
     return [
         ("os", check_os),
         ("python", check_python),
@@ -607,6 +688,7 @@ def _all_checks(config: Any) -> list[tuple[str, Any]]:
         ("guard", lambda: check_guard(config)),
         ("monitor", lambda: check_monitor(config)),
         ("pypi", check_pypi),
+        ("cleanup", lambda: check_cleanup(config, dry_run)),
     ]
 
 
@@ -627,10 +709,15 @@ AVAILABLE_CHECKS = [
     "guard",
     "monitor",
     "pypi",
+    "cleanup",
 ]
 
 
-def run_doctor(config: Any, only_checks: list[str] | None = None) -> DoctorReport:
+def run_doctor(
+    config: Any,
+    only_checks: list[str] | None = None,
+    dry_run: bool = False,
+) -> DoctorReport:
     """Run selected checks and return a report."""
     try:
         version_text = pkg_version("stata-mcp")
@@ -641,7 +728,7 @@ def run_doctor(config: Any, only_checks: list[str] | None = None) -> DoctorRepor
     selected = set(only_checks) if only_checks else None
     stata_cli_path: str | None = None
 
-    for check_name, check_func in _all_checks(config):
+    for check_name, check_func in _all_checks(config, dry_run=dry_run):
         if selected is not None and check_name not in selected:
             continue
 

--- a/src/stata_mcp/utils/doctor.py
+++ b/src/stata_mcp/utils/doctor.py
@@ -643,7 +643,12 @@ def check_cleanup(config: Any, dry_run: bool = False) -> CheckResult:
             },
         )
 
-    result = clean_log_files(max_age_days=clean_days, dry_run=dry_run, config=config)
+    result = clean_log_files(
+        max_age_days=clean_days,
+        dry_run=dry_run,
+        config=config,
+        candidate_files=old_files,
+    )
     if dry_run:
         return CheckResult(
             name="cleanup",


### PR DESCRIPTION
### Motivation
- Provide a built-in cleanup for old timestamp-prefixed files under the project `stata-mcp-folder` to avoid accumulation of legacy logs/tmp/do files. 
- Make cleanup configurable via project/env (`CLEAN_LOG_DAYS`) and safe to preview with a `--dry-run` option. 

### Description
- Add `src/stata_mcp/utils/clean_log.py` implementing `scan_old_files()` and `clean_log_files()` with support for 14-digit (`%Y%m%d%H%M%S`) and 20-digit (`%Y%m%d%H%M%S%f`) leading timestamps, non-recursive scanning, dry-run reporting, and per-file error accounting. 
- Add `Config.CLEAN_LOG_DAYS` in `src/stata_mcp/config.py` that reads `STATA_MCP__CLEAN_LOG_DAYS` / config file / default `-1` using existing `_get_config_value` semantics. 
- Extend CLI in `src/stata_mcp/cli/_parsers.py` to accept `--dry-run` for the `doctor` subcommand and forward the flag through `src/stata_mcp/cli/_handlers.py` into `run_doctor`. 
- Implement `check_cleanup()` in `src/stata_mcp/utils/doctor.py`, add `_format_size()` helper, register `cleanup` in `AVAILABLE_CHECKS`, and propagate `dry_run` through `_all_checks()` and `run_doctor()` to control scan vs delete behavior and reporting. 

### Testing
- Ran the test suite with `PYTHONPATH=src pytest -q` and all tests passed locally (`10 passed`, several warnings unrelated to changes). 
- Verified code compiles with `PYTHONPATH=src python -m compileall -q src` with no errors. 
- Exercised the new cleanup paths via unit test iterations during development (scan + dry-run + deletion flows) and the `doctor` flow was confirmed to forward `--dry-run` correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4b5e88e848320a49888a82ad2603a)