### PR TITLE
Strengthen Guard blacklist and prevent macro-based bypasses

### DIFF
--- a/src/stata_mcp/api/stata_do.py
+++ b/src/stata_mcp/api/stata_do.py
@@ -94,6 +94,8 @@ def stata_do(
                     "or set environment variable `STATA_MCP__IS_GUARD` to `false` (not recommended)"
                 ),
             }
+    else:
+        logging.warning("[SECURITY] Guard is disabled. Dangerous dofile commands will not be blocked.")
 
     monitors = []
     if runtime.config.IS_MONITOR and runtime.config.MAX_RAM_MB is not None:

--- a/src/stata_mcp/guard/blacklist.py
+++ b/src/stata_mcp/guard/blacklist.py
@@ -42,9 +42,17 @@ DANGEROUS_COMMANDS: Set[str] = {
     "!",          # Unix-style shell escape: !ls
     "!!",         # Extended shell command (xshell synonym): !!vi file.do
     "shell",      # Shell command execution: shell dir
+    "sh",         # Stata abbreviation for shell
     "xshell",     # Extended shell for Mac/Unix(GUI): xshell vi file.do
+    "xsh",        # Stata abbreviation for xshell
     "winexec",    # Windows program execution: winexec notepad.exe
+    "winex",      # Stata abbreviation for winexec
     "unixcmd",    # Unix command execution: unixcmd ls
+    "unixc",      # Stata abbreviation for unixcmd
+    "erase",      # File deletion command
+    "era",        # Stata abbreviation for erase
+    "rmdir",      # Directory removal command
+    "rmd",        # Stata abbreviation for rmdir
 }
 
 

--- a/src/stata_mcp/guard/validator.py
+++ b/src/stata_mcp/guard/validator.py
@@ -116,16 +116,25 @@ class GuardValidator:
         # Split code into lines for line number tracking
         lines = code.split("\n")
 
+        dangerous_local_names = self._collect_dangerous_local_names(lines)
+
         for line_num, line in enumerate(lines, start=1):
             # Skip empty lines and comments
             stripped_line = line.strip()
-            if not stripped_line or stripped_line.startswith("*"):
+            if (
+                not stripped_line
+                or stripped_line.startswith("*")
+                or stripped_line.startswith("//")
+            ):
                 continue
 
             # Strip Stata prefixes (capture, quietly, etc.) before checking
             cleaned_line = self._strip_prefixes(stripped_line, self.stata_prefixes)
             if not cleaned_line:
                 continue
+
+            macro_items = self._check_macro_expansion(cleaned_line, line_num, dangerous_local_names)
+            dangerous_items.extend(macro_items)
 
             # Check for dangerous commands
             command_items = self._check_dangerous_commands(cleaned_line, line_num)
@@ -138,6 +147,36 @@ class GuardValidator:
         # Generate report
         is_safe = len(dangerous_items) == 0
         return SecurityReport(is_safe=is_safe, dangerous_items=dangerous_items)
+
+    def _collect_dangerous_local_names(self, lines: List[str]) -> set[str]:
+        """Collect local macro names whose values are dangerous commands."""
+        dangerous_names: set[str] = set()
+        local_pattern = re.compile(r"^\s*local\s+(\w+)\s+['\"]([^'\"]+)['\"]", re.IGNORECASE)
+
+        for line in lines:
+            stripped_line = line.strip()
+            if not stripped_line or stripped_line.startswith("*") or stripped_line.startswith("//"):
+                continue
+
+            matched = local_pattern.search(line)
+            if not matched:
+                continue
+
+            local_name, local_value = matched.group(1), matched.group(2)
+            if local_value.strip().lower() in self.dangerous_commands:
+                dangerous_names.add(local_name)
+
+        return dangerous_names
+
+    @staticmethod
+    def _check_macro_expansion(line: str, line_num: int, dangerous_local_names: set[str]) -> List[RiskItem]:
+        """Check whether a line expands a dangerous local macro."""
+        items: List[RiskItem] = []
+        for local_name in dangerous_local_names:
+            macro_token = f"`{local_name}'"
+            if macro_token in line:
+                items.append(RiskItem(type="macro", content=macro_token, line=line_num))
+        return items
 
     def _check_dangerous_commands(self, line: str, line_num: int) -> List[RiskItem]:
         """Check if a line contains dangerous commands.

--- a/src/stata_mcp/guard/validator.py
+++ b/src/stata_mcp/guard/validator.py
@@ -158,7 +158,8 @@ class GuardValidator:
             if not stripped_line or stripped_line.startswith("*") or stripped_line.startswith("//"):
                 continue
 
-            matched = local_pattern.search(line)
+            cleaned_line = self._strip_prefixes(stripped_line, self.stata_prefixes)
+            matched = local_pattern.search(cleaned_line)
             if not matched:
                 continue
 
@@ -174,7 +175,7 @@ class GuardValidator:
         items: List[RiskItem] = []
         for local_name in dangerous_local_names:
             macro_token = f"`{local_name}'"
-            if macro_token in line:
+            if re.search(rf"(?<!\w)`{re.escape(local_name)}'(?!\w)", line):
                 items.append(RiskItem(type="macro", content=macro_token, line=line_num))
         return items
 

--- a/src/stata_mcp/mcp_servers.py
+++ b/src/stata_mcp/mcp_servers.py
@@ -240,6 +240,8 @@ def stata_do(
             }
         else:
             logging.info(f"✅ {dofile_path} - Security check passed")
+    else:
+        logging.warning("[SECURITY] Guard is disabled. Dangerous dofile commands will not be blocked.")
 
     # Initialize monitors
     monitors = []

--- a/tests/test_guard_validator.py
+++ b/tests/test_guard_validator.py
@@ -1,0 +1,35 @@
+"""Tests for guard blacklist and validator protections."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from stata_mcp.guard.blacklist import DANGEROUS_COMMANDS
+from stata_mcp.guard.validator import GuardValidator
+
+
+def test_dangerous_command_abbreviations_are_blacklisted() -> None:
+    expected = {"sh", "xsh", "winex", "unixc", "era", "rmd"}
+    assert expected.issubset(DANGEROUS_COMMANDS)
+
+
+def test_macro_expansion_with_dangerous_local_is_flagged() -> None:
+    code = 'local cmd "shell"\n`cmd\' "rm -rf /"'  # noqa: S608
+    report = GuardValidator().validate(code)
+    assert report.is_safe is False
+    assert any(item.type == "macro" and item.content == "`cmd'" for item in report.dangerous_items)
+
+
+def test_macro_expansion_with_safe_local_is_not_flagged() -> None:
+    code = 'local cmd "regress"\n`cmd\' y x'
+    report = GuardValidator().validate(code)
+    assert report.is_safe is True
+
+
+def test_commented_local_definition_is_ignored() -> None:
+    code = '* local cmd "shell"\n`cmd\' "rm -rf /"'  # noqa: S608
+    report = GuardValidator().validate(code)
+    assert report.is_safe is True

--- a/tests/test_guard_validator.py
+++ b/tests/test_guard_validator.py
@@ -33,3 +33,16 @@ def test_commented_local_definition_is_ignored() -> None:
     code = '* local cmd "shell"\n`cmd\' "rm -rf /"'  # noqa: S608
     report = GuardValidator().validate(code)
     assert report.is_safe is True
+
+
+def test_macro_expansion_does_not_match_substring_macro_name() -> None:
+    code = 'local cmd "shell"\n`cmdline\' "rm -rf /"'  # noqa: S608
+    report = GuardValidator().validate(code)
+    assert report.is_safe is True
+
+
+def test_prefixed_local_definition_is_detected() -> None:
+    code = 'qui local cmd "shell"\n`cmd\' "rm"'  # noqa: S608
+    report = GuardValidator().validate(code)
+    assert report.is_safe is False
+    assert any(item.type == "macro" and item.content == "`cmd'" for item in report.dangerous_items)

--- a/tests/test_stata_do_boundary.py
+++ b/tests/test_stata_do_boundary.py
@@ -226,3 +226,27 @@ def test_stata_do_rejects_when_allowed_directories_are_empty(monkeypatch: pytest
 
     assert result["error"].startswith("Access denied")
     assert result["allowed_directories"] == []
+
+
+def test_stata_do_logs_warning_when_guard_is_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    loaded_mcp_servers,
+    tmp_path: Path,
+):
+    do_dir = tmp_path / "do"
+    do_dir.mkdir()
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    dofile = work_dir / "ok.do"
+    dofile.write_text("display 1")
+    log_file = tmp_path / "run.log"
+    log_file.write_text("ok")
+
+    _configure_base(monkeypatch, loaded_mcp_servers, do_dir, work_dir, tmp_path)
+    _patch_stata_module(monkeypatch, log_file)
+
+    with caplog.at_level("WARNING"):
+        loaded_mcp_servers.stata_do(dofile.as_posix())
+
+    assert any("[SECURITY] Guard is disabled" in message for message in caplog.messages)


### PR DESCRIPTION
### Motivation
- Prevent blacklist bypass via Stata minimum abbreviations and common file-operation aliases that can hide dangerous system commands.
- Detect local macro indirection where a `local` macro contains a dangerous command and is expanded later to execute it.
- Surface a clear startup/runtime warning when the Guard is disabled so dangerous dofile execution is not silent.

### Description
- Extend `DANGEROUS_COMMANDS` in `src/stata_mcp/guard/blacklist.py` to include abbreviations and aliases such as `sh`, `xsh`, `winex`, `unixc`, `era`, `rmd`, and explicit `erase`/`rmdir` entries.
- Enhance `GuardValidator` in `src/stata_mcp/guard/validator.py` with a two-pass approach that adds `_collect_dangerous_local_names` to record `local <name> "value"` definitions whose `value` matches a dangerous command, and `_check_macro_expansion` to flag usages of `` `name' `` as `RiskItem(type="macro", ...)`; also skip `//` comment lines during validation.
- Add explicit security warning logging when guard mode is disabled in both server code paths: `src/stata_mcp/mcp_servers.py` and `src/stata_mcp/api/stata_do.py`.
- Add unit tests: new `tests/test_guard_validator.py` for abbreviation coverage and macro-expansion behavior, and an added test in `tests/test_stata_do_boundary.py` to assert the guard-disabled warning is logged.

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_guard_validator.py tests/test_stata_do_boundary.py` and the test suite passed (`13 passed`).
- Ran `pre-commit run --all-files` in this environment and it failed because `pre-commit` is not installed (`pre-commit: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5cbe4936c832087623d9e69250f7d)