### PR TITLE
Rename plugin display name to MCP-for-Stata and update repository links

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "stata-toolbox",
       "source": "./plugins/stata-toolbox",
-      "description": "The official working package of Stata-MCP plugin, including mcp config and stata lsp."
+      "description": "The official working package of MCP-for-Stata plugin, including mcp config and stata lsp."
     }
   ]
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stata-toolbox",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "The official working package of MCP-for-Stata plugin, including mcp config and stata-skill.",
   "author": {
     "name": "Song Tan",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,14 +1,14 @@
 {
   "name": "stata-toolbox",
   "version": "0.1.0",
-  "description": "The official working package of Stata-MCP plugin, including mcp config and stata-skill.",
+  "description": "The official working package of MCP-for-Stata plugin, including mcp config and stata-skill.",
   "author": {
     "name": "Song Tan",
     "email": "sepinetam@gmail.com",
     "url": "https://github.com/sepinetam"
   },
   "homepage": "https://www.statamcp.com",
-  "repository": "https://github.com/sepinetam/stata-mcp",
+  "repository": "https://github.com/sepinetam/mcp-for-stata",
   "license": "AGPL-3.0",
   "keywords": ["stata", "mcp", "econometrics", "regression", "social-science", "computational-social-science"],
   "mcpServers": "../plugins/stata-toolbox/mcp.json",

--- a/plugins/stata-toolbox/plugin.json
+++ b/plugins/stata-toolbox/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stata-toolbox",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "The official working package of MCP-for-Stata plugin, including mcp config and stata lsp.",
   "author": {
     "name": "Song Tan",

--- a/plugins/stata-toolbox/plugin.json
+++ b/plugins/stata-toolbox/plugin.json
@@ -1,14 +1,14 @@
 {
   "name": "stata-toolbox",
   "version": "0.1.0",
-  "description": "The official working package of Stata-MCP plugin, including mcp config and stata lsp.",
+  "description": "The official working package of MCP-for-Stata plugin, including mcp config and stata lsp.",
   "author": {
     "name": "Song Tan",
     "email": "sepinetam@gmail.com",
     "url": "https://www.sepinetam.com"
   },
   "homepage": "https://statamcp.com",
-  "repository": "https://github.com/sepinetam/stata-mcp",
+  "repository": "https://github.com/sepinetam/mcp-for-stata",
   "license": "AGPL-3.0",
   "keywords": ["stata", "econometrics", "empirical analysis"],
   "mcpServers": {

--- a/plugins/stata-toolbox/skills/stata-skill/SKILL.md
+++ b/plugins/stata-toolbox/skills/stata-skill/SKILL.md
@@ -2,17 +2,17 @@
 name: stata-skill
 version: 1.0.0
 description: |
-  A packaged Stata Runner skill via official Stata-MCP server including stata_do, ado_package_install, help, read_log and get_data_info tools. Use it when (1) need to execute Stata do-file; (2) missing ado-packages; (3) find code error caused by syntax in Stata; (4) want to read smcl and text format log file with rich text output; (5) first encounter a data file and want to understand its structure and content.
+  A packaged Stata Runner skill via official MCP-for-Stata server including stata_do, ado_package_install, help, read_log and get_data_info tools. Use it when (1) need to execute Stata do-file; (2) missing ado-packages; (3) find code error caused by syntax in Stata; (4) want to read smcl and text format log file with rich text output; (5) first encounter a data file and want to understand its structure and content.
 ---
 
-# Stata-MCP
-> Official plugin for Stata-MCP maintained by the [StataMCP-Team](https://github.com/statamcp-team), in collaboration with [SepineTam](https://github.com/sepinetam).
+# MCP-for-Stata
+> Official plugin for MCP-for-Stata maintained by the [StataMCP-Team](https://github.com/statamcp-team), in collaboration with [SepineTam](https://github.com/sepinetam).
 
-[Stata-MCP](https://statamcp.com) is an MCP (Model Context Protocol) server that exposes Stata's statistical and econometric capabilities to LLMs. This toolset supports executing do-files, querying data file structures, installing ado packages, reading Stata logs, and looking up command documentation. 
+[MCP-for-Stata](https://statamcp.com) is an MCP (Model Context Protocol) server that exposes Stata's statistical and econometric capabilities to LLMs. This toolset supports executing do-files, querying data file structures, installing ado packages, reading Stata logs, and looking up command documentation. 
 
 ## Prerequisites
 
-This skill requires the Stata-MCP server to be installed and running. If you have not configured it yet, follow `@references/installation.md`. After installation, verify with `uvx stata-mcp doctor`. Restart your AI client after installation (required for the first-time setup).
+This skill requires the MCP-for-Stata server to be installed and running. If you have not configured it yet, follow `@references/installation.md`. After installation, verify with `uvx stata-mcp doctor`. Restart your AI client after installation (required for the first-time setup).
 
 ## When to Use
 
@@ -160,7 +160,7 @@ This tool is disabled by default and only available when `STATA_MCP__ENABLE_WRIT
 
 | Name | Location | Description |
 |:---|:---|:---|
-| Installation | `@references/installation.md` | Installation and configuration guide for Stata-MCP |
+| Installation | `@references/installation.md` | Installation and configuration guide for MCP-for-Stata |
 | stata_do | `@references/stata_do.md` | Detailed guide for the execution tool |
 | get_data_info | `@references/get_data_info.md` | Detailed guide for the data exploration tool |
 | help | `@references/help.md` | Detailed guide for the documentation tool |
@@ -168,5 +168,5 @@ This tool is disabled by default and only available when `STATA_MCP__ENABLE_WRIT
 | ado_package_install | `@references/ado_package_install.md` | Detailed guide for the package installer tool |
 | Documentation | [docs.statamcp.com](https://docs.statamcp.com) | Full user documentation |
 | Homepage | [statamcp.com](https://statamcp.com) | Project homepage |
-| Source Code | [github.com/sepinetam/stata-mcp](https://github.com/sepinetam/stata-mcp) | GitHub repository |
+| Source Code | [github.com/sepinetam/mcp-for-stata](https://github.com/sepinetam/mcp-for-stata) | GitHub repository |
 

--- a/plugins/stata-toolbox/skills/stata-skill/SKILL.md
+++ b/plugins/stata-toolbox/skills/stata-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stata-skill
-version: 1.0.0
+version: 1.0.1
 description: |
   A packaged Stata Runner skill via official MCP-for-Stata server including stata_do, ado_package_install, help, read_log and get_data_info tools. Use it when (1) need to execute Stata do-file; (2) missing ado-packages; (3) find code error caused by syntax in Stata; (4) want to read smcl and text format log file with rich text output; (5) first encounter a data file and want to understand its structure and content.
 ---

--- a/plugins/stata-toolbox/skills/stata-skill/SKILL.md
+++ b/plugins/stata-toolbox/skills/stata-skill/SKILL.md
@@ -6,7 +6,7 @@ description: |
 ---
 
 # MCP-for-Stata
-> Official plugin for MCP-for-Stata maintained by the [StataMCP-Team](https://github.com/statamcp-team), in collaboration with [SepineTam](https://github.com/sepinetam).
+> Official plugin for MCP-for-Stata maintained in collaboration with [SepineTam](https://github.com/sepinetam).
 
 [MCP-for-Stata](https://statamcp.com) is an MCP (Model Context Protocol) server that exposes Stata's statistical and econometric capabilities to LLMs. This toolset supports executing do-files, querying data file structures, installing ado packages, reading Stata logs, and looking up command documentation. 
 

--- a/plugins/stata-toolbox/skills/stata-skill/references/installation.md
+++ b/plugins/stata-toolbox/skills/stata-skill/references/installation.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Stata-MCP runs via `uvx` without system installation. You only need to register it as an MCP server in your AI client.
+MCP-for-Stata runs via `uvx` without system installation. You only need to register it as an MCP server in your AI client.
 
 ## Automatic Registration (Recommended)
 
@@ -10,15 +10,15 @@ Stata-MCP runs via `uvx` without system installation. You only need to register 
 
 **macOS / Linux:**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/SepineTam/stata-mcp/master/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/SepineTam/mcp-for-stata/master/scripts/install.sh | bash
 ```
 
 **Windows (PowerShell):**
 ```powershell
-irm https://raw.githubusercontent.com/SepineTam/stata-mcp/master/scripts/install.ps1 | iex
+irm https://raw.githubusercontent.com/SepineTam/mcp-for-stata/master/scripts/install.ps1 | iex
 ```
 
-This script auto-installs `uv` if missing, then registers Stata-MCP to all supported AI clients.
+This script auto-installs `uv` if missing, then registers MCP-for-Stata to all supported AI clients.
 
 ### If uv is already installed
 
@@ -83,5 +83,5 @@ uvx stata-mcp doctor
 
 Checks:
 - Stata executable is found
-- Stata-MCP is properly configured
+- MCP-for-Stata is properly configured
 - Required directories are writable


### PR DESCRIPTION
### Motivation
- Standardize the user-facing project name from `Stata-MCP` to `MCP-for-Stata` across plugin metadata and documentation. 
- Update repository links and raw GitHub script URLs to the new `sepinetam/mcp-for-stata` path so displayed links point to the renamed repository.

### Description
- Replaced display occurrences of `Stata-MCP` with `MCP-for-Stata` in plugin metadata and skill docs in `.claude-plugin/marketplace.json`, `.codex-plugin/plugin.json`, `plugins/stata-toolbox/plugin.json`, `plugins/stata-toolbox/skills/stata-skill/SKILL.md`, and `plugins/stata-toolbox/skills/stata-skill/references/installation.md`.
- Updated repository URLs from `https://github.com/sepinetam/stata-mcp` to `https://github.com/sepinetam/mcp-for-stata` and adjusted raw script URLs under `raw.githubusercontent.com` where they are used for installation links.
- Preserved all runtime/CLI/config identifiers and names that must not change, including `uvx stata-mcp` commands, the `"stata-mcp"` MCP server key, `"args": ["stata-mcp"]`, `stata-mcp-folder`/`stata-mcp-dofile`, and any references to `statamcp` domain or team names.
- Limited edits to presentation text and links only; no code, package names, CLI names, or MCP server config keys were modified.

### Testing
- Ran `grep -rn "github.com/sepinetam/stata-mcp" .claude-plugin .codex-plugin plugins/` to confirm there are no remaining old repository links, and the command returned no matches (success).
- Ran `grep -rn "Stata-MCP" .claude-plugin .codex-plugin plugins/ | grep -v "stata-mcp-folder\|stata-mcp-dofile\|stata-mcp doctor\|uvx stata-mcp\|stata-mcp install\|stata-mcp tool\|stata-mcp'\|\"stata-mcp\"\|statamcp"` to verify no unintended display-name occurrences remain, and the command returned no matches (success).
- Ran `grep -rn '"stata-mcp"' .claude-plugin .codex-plugin plugins/` to verify MCP server keys/args remained present, and the command showed the expected occurrences (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a103c675fc8832094d5bf97caf06796)